### PR TITLE
add telegram API call for notifications + crontab (issue #84)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -36,6 +36,9 @@ wget -q -O $directory/Caddyfile "https://raw.githubusercontent.com/felix-schott/
 echo "Downloading prometheus.yml"
 wget -q -O $directory/prometheus.yml "https://raw.githubusercontent.com/felix-schott/jamsessions/refs/tags/$tag/deploy/prometheus.yml"
 
+echo "Downloading migrations-alert.sh"
+wget -q -O $directory/migrations-alert.sh "https://raw.githubusercontent.com/felix-schott/jamsessions/refs/tags/$tag/deploy/migrations-alert.sh"
+
 [[ ! -f $directory/.env ]] && {
     echo ".env doesn't exist yet - creating file and default directories"
     touch $directory/.env
@@ -85,5 +88,12 @@ will write little bash scripts to $directory/migrations that make use the dbcli 
 
 Review the script contents and execute run-migrations.sh to apply all changes.
 EOF
+
+crontab -l | grep migrations-alert.sh -q &> /dev/null && {
+    echo "Alerting cron job already installed"
+} || {
+    echo "Installing alerting cron job";
+    (crontab -l ; echo "0 */2 * * * bash $directory/migrations-alert.sh") | crontab -
+}
 
 echo "Finished installation process - please consult the generated README file for further instructions."

--- a/deploy/migrations-alert.sh
+++ b/deploy/migrations-alert.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+[[ $1 == "" ]] && echo "Please provide the target directory of the installation as a positional argument." 1>&2 && exit 1;
+directory=$1/migrations
+
+[[ $TELEGRAM_TOKEN == "" ]] && echo "Please provide the environment variable TELEGRAM_TOKEN." 1>&2 && exit 1;
+[[ $TELEGRAM_CHAT_ID == "" ]] && echo "Please provide the environment variable TELEGRAM_CHAT_ID." 1>&2 && exit 1;
+
+send_alert () {
+  curl -X POST https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage -d '{"chat_id":'${TELEGRAM_CHAT_ID}',"text":"PENDING MIGRATIONS"}' -H 'Content-Type: application/json'
+}
+
+if [[ -d $directory ]]; then
+    ls $directory/*.sh &> /dev/null && send_alert &> /dev/null
+else
+    echo "Directory $directory does not exist" 1>&2 && exit 1
+fi


### PR DESCRIPTION
PR adds a `migrations-alert.sh script` which gets installed as a cron job in `install.sh`. The former script makes a Telegram API call to send a message to a given account if the migrations directory is non-empty.